### PR TITLE
fix: update og:image URLs to use absolute paths

### DIFF
--- a/src/routes/chapters/[chapter]/index.tsx
+++ b/src/routes/chapters/[chapter]/index.tsx
@@ -265,8 +265,7 @@ export const head: DocumentHead = ({ resolveValue, params }) => {
       },
       {
         property: "og:image",
-        content:
-          chapterData.chapterMeta?.heroImage || "/images/valletta-skyline.png",
+        content: `https://constitutionofmalta.com${chapterData.chapterMeta?.heroImage || "/images/valletta-skyline.png"}`,
       },
       {
         name: "article:section",

--- a/src/routes/chapters/index.tsx
+++ b/src/routes/chapters/index.tsx
@@ -73,7 +73,7 @@ export const head: DocumentHead = {
     },
     {
       property: "og:image",
-      content: "/images/valletta-skyline.png",
+      content: "https://constitutionofmalta.com/images/valletta-skyline.png",
     },
   ],
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -113,7 +113,7 @@ export const head: DocumentHead = {
     },
     {
       property: "og:image",
-      content: "/images/valletta-skyline.png",
+      content: "https://constitutionofmalta.com/images/valletta-skyline.png",
     },
     {
       name: "viewport",

--- a/src/routes/overview/index.tsx
+++ b/src/routes/overview/index.tsx
@@ -177,7 +177,7 @@ export const head: DocumentHead = {
     },
     {
       property: "og:image",
-      content: "/images/valletta-skyline.png",
+      content: "https://constitutionofmalta.com/images/valletta-skyline.png",
     },
     {
       name: "article:section",


### PR DESCRIPTION
This pull request updates the `og:image` meta tag across multiple pages to use an absolute URL instead of a relative path, ensuring proper rendering of Open Graph images when shared on external platforms.

### Updates to `og:image` meta tag:

* `src/routes/chapters/[chapter]/index.tsx`: Changed the `og:image` content to use an absolute URL, dynamically including the `heroImage` if available or falling back to a default image. ([src/routes/chapters/[chapter]/index.tsxL268-R268](diffhunk://#diff-18729aa5ef84a75af6b56eae7342e051b869dac821c6d5b71c14e0af08d50a0cL268-R268))
* [`src/routes/chapters/index.tsx`](diffhunk://#diff-283ac008bcb4ad8d7d228d50b6ef588a9ca7ee67953a4d86244475ba32095a9eL76-R76): Replaced the relative path for the `og:image` content with the absolute URL `https://constitutionofmalta.com/images/valletta-skyline.png`.
* [`src/routes/index.tsx`](diffhunk://#diff-3d4d2177c21702138c6c0473b20d38d819dec2249dd99cbf1d00fde1f6ac5115L116-R116): Updated the `og:image` content to use the absolute URL `https://constitutionofmalta.com/images/valletta-skyline.png`.
* [`src/routes/overview/index.tsx`](diffhunk://#diff-a4f6dbfd9dc4d2ce28e3ac5303c5cec1d886a80115b76e9ddf98030297e03ea9L180-R180): Updated the `og:image` content to use the absolute URL `https://constitutionofmalta.com/images/valletta-skyline.png`.